### PR TITLE
Quick use fix

### DIFF
--- a/HelpfulHotkeys.cs
+++ b/HelpfulHotkeys.cs
@@ -114,13 +114,13 @@ namespace HelpfulHotkeys
 						RecallItems.Add(Convert.ToInt32(args[1]));
 						return "Success";
 					default:
-						ErrorLogger.Log("HelpfulHotkeys: Unknown Message type: " + messageType);
+						Logger.Warn("Unknown Message type: " + messageType);
 						return "Failure";
 				}
 			}
 			catch (Exception e)
 			{
-				ErrorLogger.Log("HelpfulHotkeys Call Error: " + e.StackTrace + e.Message);
+				Logger.Warn("Call Error: " + e.StackTrace + e.Message);
 			}
 			return "Failure";
 		}
@@ -168,7 +168,7 @@ namespace HelpfulHotkeys
 					if (Main.mouseLeft && Main.mouseLeftRelease)
 					{
 						Main.mouseLeftRelease = false;
-						HelpfulHotkeysPlayer modPlayer = Main.LocalPlayer.GetModPlayer<HelpfulHotkeysPlayer>(this);
+						HelpfulHotkeysPlayer modPlayer = Main.LocalPlayer.GetModPlayer<HelpfulHotkeysPlayer>();
 						modPlayer.smartQuickStack();
 						Recipe.FindRecipes();
 					}
@@ -216,7 +216,7 @@ namespace HelpfulHotkeys
 					{
 						return;
 					}
-					HelpfulHotkeysPlayer modPlayer = player.GetModPlayer<HelpfulHotkeysPlayer>(this);
+					HelpfulHotkeysPlayer modPlayer = player.GetModPlayer<HelpfulHotkeysPlayer>();
 					modPlayer.smartQuickStack();
 					Recipe.FindRecipes();
 				}

--- a/HelpfulHotkeysPlayer.cs
+++ b/HelpfulHotkeysPlayer.cs
@@ -67,10 +67,7 @@ namespace HelpfulHotkeys
 			}
 			if (HelpfulHotkeys.QuickUseItem20Hotkey.JustPressed)
 			{
-				if (player.selectedItem != ITEM20)
-				{
-					QuickUseItemAt(ITEM20);
-				}
+				QuickUseItemAt(ITEM20);
 			}
 			if (HelpfulHotkeys.QuickUseConfigItemHotkey.JustPressed) {
 				QuickUseConfigItem();
@@ -558,7 +555,7 @@ namespace HelpfulHotkeys
 
 		public void QuickUseItemAt(int index, bool use = true)
 		{
-			if (player.inventory[index].type != 0)
+			if (!autoRevertSelectedItem && player.selectedItem != index && player.inventory[index].type != 0)
 			{
 				originalSelectedItem = player.selectedItem;
 				autoRevertSelectedItem = true;

--- a/HelpfulHotkeysPlayer.cs
+++ b/HelpfulHotkeysPlayer.cs
@@ -14,6 +14,7 @@ namespace HelpfulHotkeys
 {
 	public class HelpfulHotkeysPlayer : ModPlayer
 	{
+		internal const int ITEM20 = 19;
 		internal int originalSelectedItem;
 		internal bool autoRevertSelectedItem = false;
 		internal bool autoCycleAmmo = false;
@@ -66,7 +67,10 @@ namespace HelpfulHotkeys
 			}
 			if (HelpfulHotkeys.QuickUseItem20Hotkey.JustPressed)
 			{
-				QuickUseItem20();
+				if (player.selectedItem != ITEM20)
+				{
+					QuickUseItemAt(ITEM20);
+				}
 			}
 			if (HelpfulHotkeys.QuickUseConfigItemHotkey.JustPressed) {
 				QuickUseConfigItem();
@@ -220,7 +224,7 @@ namespace HelpfulHotkeys
 		public Item QuickMountCycle_GetItemToUse(int lastMount)
 		{
 			bool lastMountFound = false;
-			bool lastMountPassed = false;
+			//bool lastMountPassed = false;
 			Item item = null;
 			if (item == null && player.miscEquips[3].mountType != -1 && !MountID.Sets.Cart[player.miscEquips[3].mountType] && ItemLoader.CanUseItem(player.miscEquips[3], player))
 			{
@@ -552,15 +556,18 @@ namespace HelpfulHotkeys
 			Main.NewText("Autopause turned " + (Main.autoPause ? "on" : "off"));
 		}
 
-		public void QuickUseItem20()
+		public void QuickUseItemAt(int index, bool use = true)
 		{
-			if (player.inventory[19].type != 0)
+			if (player.inventory[index].type != 0)
 			{
 				originalSelectedItem = player.selectedItem;
 				autoRevertSelectedItem = true;
-				player.selectedItem = 19;
+				player.selectedItem = index;
 				player.controlUseItem = true;
-				player.ItemCheck(Main.myPlayer);
+				if (use)
+				{
+					player.ItemCheck(Main.myPlayer);
+				}
 			}
 		}
 
@@ -575,11 +582,7 @@ namespace HelpfulHotkeys
 				Main.NewText($"Quick Use Config Item \"{Lang.GetItemNameValue(type)}\" not found in inventory.");
 				return;
 			}
-			originalSelectedItem = player.selectedItem;
-			autoRevertSelectedItem = true;
-			player.selectedItem = index;
-			player.controlUseItem = true;
-			player.ItemCheck(Main.myPlayer);
+			QuickUseItemAt(index);
 		}
 
 		public void SmartQuickStackToChests()
@@ -630,10 +633,7 @@ namespace HelpfulHotkeys
 			{
 				if (TileLoader.IsTorch(player.inventory[i].createTile))
 				{
-					originalSelectedItem = player.selectedItem;
-					autoRevertSelectedItem = true;
-					player.selectedItem = i;
-					player.controlUseItem = true;
+					QuickUseItemAt(i, use: false);
 					Player.tileTargetX = (int)(player.Center.X / 16);
 					Player.tileTargetY = (int)(player.Center.Y / 16);
 					int oldstack = player.inventory[player.selectedItem].stack;
@@ -681,11 +681,7 @@ namespace HelpfulHotkeys
 			{
 				if (HelpfulHotkeys.RecallItems.Contains(player.inventory[i].type))
 				{
-					originalSelectedItem = player.selectedItem;
-					autoRevertSelectedItem = true;
-					player.selectedItem = i;
-					player.controlUseItem = true;
-					player.ItemCheck(Main.myPlayer);
+					QuickUseItemAt(i);
 					break;
 				}
 			}


### PR DESCRIPTION
noticed a bug with the "use item" hotkeys
if you press them once, and the item is in use, and then press it again, your selected item won't change back

This PR fixes it