### PR TITLE
(Revised) Add Shellphone to recall items list

### DIFF
--- a/HelpfulHotkeys.cs
+++ b/HelpfulHotkeys.cs
@@ -78,10 +78,10 @@ namespace HelpfulHotkeys
 				ItemID.MagicMirror,
 				ItemID.IceMirror,
 				ItemID.CellPhone,
-				ItemID.RecallPotion
-    				ItemID.Shellphone
-				ItemID.ShellphoneSpawn
-    				ItemID.ShellphoneOcean
+				ItemID.RecallPotion,
+				ItemID.Shellphone,
+				ItemID.ShellphoneSpawn,
+				ItemID.ShellphoneOcean,
 				ItemID.ShellphoneHell
 			});
 

--- a/HelpfulHotkeys.cs
+++ b/HelpfulHotkeys.cs
@@ -79,6 +79,10 @@ namespace HelpfulHotkeys
 				ItemID.IceMirror,
 				ItemID.CellPhone,
 				ItemID.RecallPotion
+    				ItemID.Shellphone
+				ItemID.ShellphoneSpawn
+    				ItemID.ShellphoneOcean
+				ItemID.ShellphoneHell
 			});
 
 			/*var loadModsField = Assembly.GetCallingAssembly().GetType("Terraria.ModLoader.Interface").GetField("loadMods", BindingFlags.Static | BindingFlags.NonPublic);


### PR DESCRIPTION
Sorry about that, I (far overly hastily) deleted the old fork so it's not letting me re-open the PR. Still kind of getting used to github, so that one's on me.
This all works, though. It won't let you toggle through it, obviously, but it'll activate whatever teleport it's currently set to.